### PR TITLE
Remove use of etc/jetty-testrealm.xml

### DIFF
--- a/jetty_files/start.ini
+++ b/jetty_files/start.ini
@@ -1,6 +1,6 @@
 #===========================================================
 # Jetty start.jar arguments
-# Each line of this file is prepended to the command line 
+# Each line of this file is prepended to the command line
 # arguments # of a call to:
 #    java -jar start.jar [arg...]
 #===========================================================
@@ -8,9 +8,9 @@
 
 
 #===========================================================
-# If the arguements in this file include JVM arguments 
+# If the arguements in this file include JVM arguments
 # (eg -Xmx512m) or JVM System properties (eg com.sun.???),
-# then these will not take affect unless the --exec 
+# then these will not take affect unless the --exec
 # parameter is included or if the output from --dry-run
 # is executed like:
 #   eval $(java -jar start.jar --dry-run)
@@ -33,7 +33,7 @@
 # -XX:+DisableExplicitGC
 # -XX:+UseConcMarkSweepGC
 # -XX:ParallelCMSThreads=2
-# -XX:+CMSClassUnloadingEnabled  
+# -XX:+CMSClassUnloadingEnabled
 # -XX:+UseCMSCompactAtFullCollection
 # -XX:CMSInitiatingOccupancyFraction=80
 #-----------------------------------------------------------
@@ -64,6 +64,6 @@ etc/jetty-deploy.xml
 #etc/jetty-overlay.xml
 etc/jetty-webapps.xml
 # etc/jetty-contexts.xml
-etc/jetty-testrealm.xml
+# etc/jetty-testrealm.xml
 # etc/jetty-jaas.xml
 #===========================================================


### PR DESCRIPTION
@steve  

This branch removes jetty's use of etc/jetty-testrealm.xml.  I'm not sure why it was ever included, but we tested without it and everything seems to work fine.
