### PR TITLE
Remove RAILS_ENV requirement if not a rails app

### DIFF
--- a/jetty_files/jetty-init.erb
+++ b/jetty_files/jetty-init.erb
@@ -135,7 +135,7 @@ running()
     ps -p $PID >/dev/null 2>/dev/null || return 1
     return 0
 }
-
+<% if @settings.rails? %>
 ensure_rails_env_set()
 {
 	if [ -z "$RAILS_ENV" ]; then
@@ -143,6 +143,7 @@ ensure_rails_env_set()
 		exit 1
 	fi
 }
+<% end %>
 
 
 
@@ -532,7 +533,9 @@ RUN_CMD="$JAVA $RUN_ARGS"
 ##################################################
 case "$ACTION" in
   start)
+	<% if @settings.rails? %>
 	ensure_rails_env_set
+	<% end %>
 	echo -n "Starting Jetty: "
 
 	if [ "$NO_START" = "1" ]; then
@@ -629,8 +632,10 @@ case "$ACTION" in
         ;;
 
   restart)
+	<% if @settings.rails? %>
         ensure_rails_env_set
-        JETTY_SH=$0
+        <% end %>
+	JETTY_SH=$0
         if [ ! -f $JETTY_SH ]; then
           if [ ! -f $JETTY_HOME/bin/jetty.sh ]; then
             echo "$JETTY_HOME/bin/jetty.sh does not exist."


### PR DESCRIPTION
jetty-init should not require RAILS_ENV to be set if app_type is not rails.
