### PR TITLE
add back and enable extended logging capabilities

### DIFF
--- a/jetty_files/etc/jetty.xml.erb
+++ b/jetty_files/etc/jetty.xml.erb
@@ -115,4 +115,27 @@
         </New>
       </Arg>
     </New>
+
+    <Ref id="Handlers">
+      <Call name="addHandler">
+        <Arg>
+          <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler">
+            <Set name="requestLog">
+              <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
+                <Set name="filename"><Property name="jetty.home"/>/../../log/jetty_request_yyyy_mm_dd.log</Set>
+                <Set name="filenameDateFormat">yyyy_MM_dd</Set>
+                <Set name="retainDays">30</Set>
+                <Set name="append">true</Set>
+                <Set name="extended">true</Set>
+                <Set name="logLatency">true</Set>
+                <Set name="logDispatch">true</Set>
+                <Set name="preferProxiedForAddress">true</Set>
+                <Set name="logCookies">false</Set>
+                <Set name="LogTimeZone">GMT</Set>
+              </New>
+            </Set>
+          </New>
+        </Arg>
+      </Call>
+    </Ref>
 </Configure>


### PR DESCRIPTION
- request latency and dispatch timing
- user-agents
- usage of X-Forwarded-For: header over requesting IP if present

it turns the request log from:

`172.16.9.7 -  -  [23/May/2012:22:03:18 +0000] "GET /blah HTTP/1.1" 200 55`

into

`74.122.184.28 -  -  [23/May/2012:22:27:09 +0000] "GET /blah HTTP/1.1" 200 55 "-" "User-Agent" 47 47`
