### PR TITLE
Add license for Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2012 Square Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+


### PR DESCRIPTION
Hi there, there's currently no license attached to this project. For your convenience, this pull request would license this project under Apache 2.0 with the same copyright holder as your other repos, e.g. https://github.com/square/fdoc/blob/master/LICENSE
