### PR TITLE
fix overwriting of files in vendor

### DIFF
--- a/bin/jetpack
+++ b/bin/jetpack
@@ -132,7 +132,7 @@ def process_template_files(erb_files)
 
     # Need to override vendor files because jetpack itself installs jetty
     # there, which includes files we need to overwrite.
-    next if target_file[0..8] != './vendor/' && File.exists?(target_file)
+    next if File.exists?(target_file) && target_file !~ /\/vendor\//
 
     evaled_contents = ERB.new(File.read(erb_file)).result(binding)
     File.open(target_file, "w"){|f|f<<evaled_contents}


### PR DESCRIPTION
@xaviershay @rudle @zachmargolis

This fixes jetpack's not ERB'ing files correctly and thus, our deploy.
