### PR TITLE
Explicitly use bash for jett-init due to bash-specific commands

### DIFF
--- a/jetty_files/jetty-init.erb
+++ b/jetty_files/jetty-init.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # chkconfig: 3 99 99
 # description: Finance Jetty 6 webserver


### PR DESCRIPTION
When setting an environment script via jetpack.yml, the rendered jetty-init file executes it using the source command.  This is a bash specific command which may not be the shell provided by /bin/sh.
