### PR TITLE
Use java from jetpack.yml to execute jruby

### DIFF
--- a/bin_files/ruby.erb
+++ b/bin_files/ruby.erb
@@ -3,5 +3,4 @@
 cd $(dirname $0)/..
 
 export RUBY=bin/ruby #This is needed to prevent rake from exploding
-
-<%=@java_dash_jar%> <%=@jruby_jar_file%> <%=@jruby_opts%> "$@"
+GEM_HOME=#{@gem_home} exec <%=@settings.java%> <%=@jar_build_options%> -jar <%=@jruby_jar_file%> <%=@jruby_opts%> "$@"


### PR DESCRIPTION
The existing ruby template interpolation uses `exec java` which utilizes the java that is on your PATH. This uses the java that is specified in the jetpack configuration.

Specs fail for me, but they fail on master anyway.
