### PR TITLE
Clean bundle after install

### DIFF
--- a/bin/jetpack
+++ b/bin/jetpack
@@ -91,7 +91,7 @@ end
 def bundle_install
   jruby! "-S gem install bundler -i #{@gem_home} --no-rdoc --no-ri"
   regenerate_gemfile_lock_if_platform_java_is_not_found
-  jruby! "#{@gem_home}/bin/bundle --deployment --without test development"
+  jruby! "#{@gem_home}/bin/bundle --deployment --clean --without test development"
   jruby! "#{@gem_home}/bin/bundle binstubs rake"
 end
 


### PR DESCRIPTION
This allows you to cache your bundle between builds to speed up jetpack.
The downside of caching is that you can end up with a lot of stale gems
in the bundle, which can negatively affect app load time. With the
--clean option, only the currently used gems are left in the bundle.

Performance impact of this change for non-cached bundles should be
minimal. In my testing there was no perceivable difference in run times
for bundle install with an unnecessary --clean.

@xaviershay
