### PR TITLE
Disable sending server version

### DIFF
--- a/jetpack.gemspec
+++ b/jetpack.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "jetpack"
-  s.version     = "0.1.4"
+  s.version     = "0.1.5"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Steve Conover", "Xavier Shay", "Taylor Phillips", "Chris Heisterkamp"]
   s.email       = ["steve@squareup.com", "xavier@squareup.com", "taylor@squareup.com", "cheister@squareup.com"]

--- a/jetty_files/etc/jetty.xml.erb
+++ b/jetty_files/etc/jetty.xml.erb
@@ -132,7 +132,7 @@
     </Set>
 
     <Set name="stopAtShutdown">true</Set>
-    <Set name="sendServerVersion">true</Set>
+    <Set name="sendServerVersion">false</Set>
     <Set name="sendDateHeader">true</Set>
     <Set name="gracefulShutdown">1</Set>
     <Set name="dumpAfterStart">false</Set>


### PR DESCRIPTION
Sending the server version is not really needed. It's better to disable it.
