### PR TITLE
Add configurable option for bundle --without

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,7 @@ Some other settings you might care about:
     keystore_type: JCEKS
     keystore: /data/app/secrets/mystore.jceks
     keystore_password: sekret
+    bundle_without: [test, development]
 
 Run Jetpack:
 

--- a/bin/jetpack
+++ b/bin/jetpack
@@ -91,7 +91,8 @@ end
 def bundle_install
   jruby! "-S gem install bundler -i #{@gem_home} --no-rdoc --no-ri"
   regenerate_gemfile_lock_if_platform_java_is_not_found
-  jruby! "#{@gem_home}/bin/bundle --deployment --clean --without test development"
+  bundle_without = @settings.bundle_without.join(' ')
+  jruby! "#{@gem_home}/bin/bundle --deployment --clean --without #{bundle_without}"
   jruby! "#{@gem_home}/bin/bundle binstubs rake"
 end
 

--- a/lib/jetpack/settings.rb
+++ b/lib/jetpack/settings.rb
@@ -26,6 +26,7 @@ module Jetpack
         'truststore'                 => nil,
         'truststore_password'        => nil,
         'reload_keystore'            => false,
+        'bundle_without'             => %w(test development)
       }
 
       contents = defaults.merge(user_defined_options)

--- a/spec/bundler_spec.rb
+++ b/spec/bundler_spec.rb
@@ -64,6 +64,13 @@ describe "jetpack - bundler and gems" do
       rake_result[:stdout].should     == "Spruz::Bijection\n"
       rake_result[:exitstatus].should == 0
     end
+
+    it "does not bundle groups specified in bundle_without" do
+      rake_result = x("cd spec/sample_projects/has_gems_via_bundler && " +
+                          %{bin/ruby -e 'require \\"rubygems\\"; require \\"bundler/setup\\"; require \\"honor_codes\\"; puts HonorCodes.name'})
+      rake_result[:stderr].should     =~ /LoadError: no such file to load -- honor_codes/
+      rake_result[:exitstatus].should > 0
+    end
   end
 
   describe "bin/rake" do

--- a/spec/sample_projects/has_gems_via_bundler/Gemfile
+++ b/spec/sample_projects/has_gems_via_bundler/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 gem "rake", "~> 0.9.2"
 gem "spruz"
+
+group :exclusion do
+  gem "honor_codes"
+end

--- a/spec/sample_projects/has_gems_via_bundler/Gemfile.lock
+++ b/spec/sample_projects/has_gems_via_bundler/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     rake (0.9.2.2)
     spruz (0.2.13)
+    honor_codes (0.1.1)
 
 PLATFORMS
   java
@@ -11,3 +12,4 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 0.9.2)
   spruz
+  honor_codes

--- a/spec/sample_projects/has_gems_via_bundler/config/jetpack.yml
+++ b/spec/sample_projects/has_gems_via_bundler/config/jetpack.yml
@@ -1,1 +1,2 @@
+bundle_without: [exclusion]
 jruby: "file://<%= File.expand_path('spec/local_mirror') %>/jruby-complete-1.7.12.jar"

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -53,6 +53,10 @@ describe Jetpack::Settings do
       it "sets keystore_password" do
         subject.keystore_password.should be_nil
       end
+
+      it "sets bundle_without" do
+        subject.bundle_without.should =~ %w(test development)
+      end
     end
 
     context "optional parameters" do


### PR DESCRIPTION
We have more groups in our Gemfile and need a way to specify the groups for bundle --without in jetpack.yml. 

Still defaults to [test, development]
