### PR TITLE
Update to most recent bundler (~> 1.12.5)

### DIFF
--- a/bin/jetpack
+++ b/bin/jetpack
@@ -86,7 +86,7 @@ def regenerate_gemfile_lock_if_platform_java_is_not_found
 end
 
 def bundle_install
-  jruby!("-S gem install bundler -v '~> 1.9.9' --conservative -i #{@gem_home} --no-rdoc --no-ri")
+  jruby!("-S gem install bundler -v '~> 1.12.5' --conservative -i #{@gem_home} --no-rdoc --no-ri")
   regenerate_gemfile_lock_if_platform_java_is_not_found
   bundle_without = @settings.bundle_without.join(' ')
   jruby!("#{@gem_home}/bin/bundle --deployment --clean --without #{bundle_without}")


### PR DESCRIPTION
Bundler 1.9 does not handle `source` blocks very well.