### PR TITLE
Fix tests after 2 years of rot

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - 'vendor/bundle/**/*'
+    - 'spec/sample_projects/**/vendor/*'
 
 # Offense count: 1
 Lint/UselessAssignment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ cache: bundler
 language: ruby
 rvm:
   - 2.1
+jdk:
+  - oraclejdk8
 script:
+  - jdk_switcher use oraclejdk8
   - bundle exec rake spec
   - bundle exec rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ namespace :spec do
 
     FileUtils.mkdir_p 'spec/local_mirror' unless File.directory?('spec/local_mirror')
 
-    local_mirror 'http://jruby.org.s3.amazonaws.com/downloads/1.7.25/jruby-complete-1.7.25.jar'
+    local_mirror 'https://repo1.maven.org/maven2/org/jruby/jruby-complete/1.7.25/jruby-complete-1.7.25.jar'
     local_mirror 'http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.2.18.v20160721/jetty-distribution-9.2.18.v20160721.zip'
     local_mirror 'http://central.maven.org/maven2/org/jruby/rack/jruby-rack/1.1.20/jruby-rack-1.1.20.jar'
   end

--- a/bin/jetpack
+++ b/bin/jetpack
@@ -143,7 +143,8 @@ end
 
 def overlay_files(overlay_dir, target_dir)
   files_created = note_files_created(target_dir) do
-    cp_options = '-rpL'
+    # copy with recursive, preserve (mode, ownership, timestamps), and follow symbolic links
+    cp_options = '-RpL'
     cp_options += ' -v' if ENV['VERBOSE']
     x!("cp #{cp_options} #{overlay_dir}/. #{target_dir}")
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,11 @@ include FileUtils
 # Cleanse the environment of these vars so that jruby is not affected.
 ENV.delete_if { |k, _| k =~ /^(RUBY|BUNDLE|GEM|_JAVA_OPTIONS)/ }
 
+# Set JAVA_HOME to Java 8. Jruby 1.7.x does not work with Java 9 and up.
+if RbConfig::CONFIG['host_os'] =~ /darwin/
+  ENV['JAVA_HOME'] = `/usr/libexec/java_home -v 1.8`.chomp
+end
+
 def x(cmd)
   stdout = StringIO.new
   stderr = StringIO.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ include FileUtils
 
 # Env vars like RUBYOPT get passed on to jruby.
 # Cleanse the environment of these vars so that jruby is not affected.
-ENV.delete_if { |k, _| k =~ /^(RUBY|BUNDLE|GEM)/ }
+ENV.delete_if { |k, _| k =~ /^(RUBY|BUNDLE|GEM|_JAVA_OPTIONS)/ }
 
 def x(cmd)
   stdout = StringIO.new


### PR DESCRIPTION
The main problem is the url for jruby-complete-1.7.25.jar was 404ing. Second big problem was _JAVA_OPTIONS being set by Travis and causing stderr leakage.